### PR TITLE
Fix for grammar error in #2

### DIFF
--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -372,7 +372,7 @@
 
   "digest.subject": "Your Waldi daily digest",
   "digest.line": "\"%s\" — %s",
-  "digest.clause.readers": "%d people read this.",
+  "digest.clause.readers": "%d read this.",
   "digest.clause.completed": "%d finished it.",
   "digest.clause.follows": "%d followed you afterward.",
   "digest.clause.letters": "%d letters arrived for it.",


### PR DESCRIPTION
## What does this change?

This responds to the problem in #2 and proposes a simple change of deleting the word "people" to make sure the grammar is always correct. 

Note that there may be other places this will pop up, e.g. I bet `digest.clause.letters": "%d letters arrived for it."` is also going to cause a problem when "1 letters arrived" so maybe a more comprehensive solution is required. 

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [ ] Added/updated tests for the change (especially for `internal/post`)
- [ ] Added a new migration file if the schema changed (never edited an applied one)
- [ ] Updated docs (`README.md`, `DEPLOY.md`, `.env.example`) if behavior or config changed
